### PR TITLE
Feat : 기본 엔티티 생성 및 JPA 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,10 +25,12 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0'
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,0 @@
-rootProject.name = 'demo'

--- a/src/main/java/com/dnd/demo/common/entity/BaseEntity.java
+++ b/src/main/java/com/dnd/demo/common/entity/BaseEntity.java
@@ -1,0 +1,26 @@
+package com.dnd.demo.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+abstract public class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false, updatable = true)
+    private LocalDateTime updatedAt;
+
+    private String deleteYn = "N";
+}

--- a/src/main/java/com/dnd/demo/domain/Quiz/entity/Quiz.java
+++ b/src/main/java/com/dnd/demo/domain/Quiz/entity/Quiz.java
@@ -1,0 +1,19 @@
+package com.dnd.demo.domain.Quiz.entity;
+
+import com.dnd.demo.common.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Quiz extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long quizId;
+
+    private Long projectId;
+    private String question;
+    private String correctOptionId;
+}

--- a/src/main/java/com/dnd/demo/domain/Quiz/entity/QuizOption.java
+++ b/src/main/java/com/dnd/demo/domain/Quiz/entity/QuizOption.java
@@ -1,0 +1,15 @@
+package com.dnd.demo.domain.Quiz.entity;
+
+
+import com.dnd.demo.common.entity.BaseEntity;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+
+@Entity
+public class QuizOption extends BaseEntity {
+
+    @EmbeddedId
+    private QuizOptionKey quizOptionKey;
+
+    private String text;
+}

--- a/src/main/java/com/dnd/demo/domain/Quiz/entity/QuizOptionKey.java
+++ b/src/main/java/com/dnd/demo/domain/Quiz/entity/QuizOptionKey.java
@@ -1,0 +1,18 @@
+package com.dnd.demo.domain.Quiz.entity;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+public class QuizOptionKey {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long optionId;
+    private Long quizId;
+
+}

--- a/src/main/java/com/dnd/demo/domain/Quiz/entity/QuizResult.java
+++ b/src/main/java/com/dnd/demo/domain/Quiz/entity/QuizResult.java
@@ -1,0 +1,15 @@
+package com.dnd.demo.domain.Quiz.entity;
+
+import com.dnd.demo.common.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class QuizResult extends BaseEntity {
+
+    @Id
+    private Long projectId;
+
+    private Integer participantCount;
+    private Integer passCount;
+}

--- a/src/main/java/com/dnd/demo/domain/member/entity/Comment.java
+++ b/src/main/java/com/dnd/demo/domain/member/entity/Comment.java
@@ -1,0 +1,24 @@
+package com.dnd.demo.domain.member.entity;
+
+import com.dnd.demo.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Comment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long CommentId;
+
+    @Column(nullable = false)
+    private Long projectId;
+
+    @Column(nullable = false)
+    private Long memberId;
+    
+    private String content;
+}

--- a/src/main/java/com/dnd/demo/domain/member/entity/Favorite.java
+++ b/src/main/java/com/dnd/demo/domain/member/entity/Favorite.java
@@ -12,7 +12,7 @@ public class Favorite extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private String favoriteId;
+    private Long favoriteId;
 
     @Column(nullable = false)
     private Long memberId;

--- a/src/main/java/com/dnd/demo/domain/member/entity/Favorite.java
+++ b/src/main/java/com/dnd/demo/domain/member/entity/Favorite.java
@@ -1,0 +1,22 @@
+package com.dnd.demo.domain.member.entity;
+
+import com.dnd.demo.common.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Favorite extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private String favoriteId;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @Column(nullable = false)
+    private Long projectId;
+}

--- a/src/main/java/com/dnd/demo/domain/member/entity/Member.java
+++ b/src/main/java/com/dnd/demo/domain/member/entity/Member.java
@@ -1,0 +1,19 @@
+package com.dnd.demo.domain.member.entity;
+
+import com.dnd.demo.common.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Member extends BaseEntity {
+
+    @Id
+    private Long memberId;
+
+    private String job;
+    private String level;
+    private String email;
+    private Integer points;
+    private String memberName;
+    private String profileUrl = null;
+}

--- a/src/main/java/com/dnd/demo/domain/member/entity/Member.java
+++ b/src/main/java/com/dnd/demo/domain/member/entity/Member.java
@@ -1,7 +1,12 @@
 package com.dnd.demo.domain.member.entity;
 
 import com.dnd.demo.common.entity.BaseEntity;
+import com.dnd.demo.domain.project.entity.Category;
+import com.dnd.demo.domain.project.entity.Job;
+import com.dnd.demo.domain.project.entity.Level;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 
 @Entity
@@ -10,8 +15,12 @@ public class Member extends BaseEntity {
     @Id
     private Long memberId;
 
-    private String job;
-    private String level;
+    @Enumerated(EnumType.STRING)
+    private Job job;
+    @Enumerated(EnumType.STRING)
+    private Level level;
+    @Enumerated(EnumType.STRING)
+    private Category category;
     private String email;
     private Integer points;
     private String memberName;

--- a/src/main/java/com/dnd/demo/domain/project/entity/Advertisement.java
+++ b/src/main/java/com/dnd/demo/domain/project/entity/Advertisement.java
@@ -1,0 +1,13 @@
+package com.dnd.demo.domain.project.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity
+public class Advertisement {
+
+    @Id
+    private Long projectId;
+    private String startDate;
+    private String endDate;
+}

--- a/src/main/java/com/dnd/demo/domain/project/entity/Category.java
+++ b/src/main/java/com/dnd/demo/domain/project/entity/Category.java
@@ -1,0 +1,5 @@
+package com.dnd.demo.domain.project.entity;
+
+public enum Category {
+
+}

--- a/src/main/java/com/dnd/demo/domain/project/entity/Category.java
+++ b/src/main/java/com/dnd/demo/domain/project/entity/Category.java
@@ -1,5 +1,5 @@
 package com.dnd.demo.domain.project.entity;
 
 public enum Category {
-
+    TEST
 }

--- a/src/main/java/com/dnd/demo/domain/project/entity/Job.java
+++ b/src/main/java/com/dnd/demo/domain/project/entity/Job.java
@@ -1,0 +1,4 @@
+package com.dnd.demo.domain.project.entity;
+
+public enum Job {
+}

--- a/src/main/java/com/dnd/demo/domain/project/entity/Job.java
+++ b/src/main/java/com/dnd/demo/domain/project/entity/Job.java
@@ -1,4 +1,6 @@
 package com.dnd.demo.domain.project.entity;
 
 public enum Job {
+    DEVLOPER,
+    DESIGNER;
 }

--- a/src/main/java/com/dnd/demo/domain/project/entity/Level.java
+++ b/src/main/java/com/dnd/demo/domain/project/entity/Level.java
@@ -1,4 +1,5 @@
 package com.dnd.demo.domain.project.entity;
 
 public enum Level {
+    TEST
 }

--- a/src/main/java/com/dnd/demo/domain/project/entity/Level.java
+++ b/src/main/java/com/dnd/demo/domain/project/entity/Level.java
@@ -1,0 +1,4 @@
+package com.dnd.demo.domain.project.entity;
+
+public enum Level {
+}

--- a/src/main/java/com/dnd/demo/domain/project/entity/Project.java
+++ b/src/main/java/com/dnd/demo/domain/project/entity/Project.java
@@ -1,0 +1,28 @@
+package com.dnd.demo.domain.project.entity;
+
+import com.dnd.demo.common.entity.BaseEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Project extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long projectId;
+    private String memberId;
+    private String title;
+    private String description;
+    private String startDate;
+    private String dueDate;
+    private String category;
+    private String targetJob;
+    private String targetLevel;
+    private String logoImgUrl;
+    private String thumbnailImgUrl;
+    private String status;
+    private Integer participantCount;
+    private Integer favoriteCount;
+}

--- a/src/main/java/com/dnd/demo/domain/project/entity/Project.java
+++ b/src/main/java/com/dnd/demo/domain/project/entity/Project.java
@@ -2,9 +2,12 @@ package com.dnd.demo.domain.project.entity;
 
 import com.dnd.demo.common.entity.BaseEntity;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.LocalDate;
 
 @Entity
 public class Project extends BaseEntity {
@@ -17,12 +20,17 @@ public class Project extends BaseEntity {
     private String description;
     private String startDate;
     private String dueDate;
-    private String category;
-    private String targetJob;
-    private String targetLevel;
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
+    @Enumerated(EnumType.STRING)
+    private Job targetJob;
+    @Enumerated(EnumType.STRING)
+    private Level targetLevel;
     private String logoImgUrl;
     private String thumbnailImgUrl;
     private String status;
     private Integer participantCount;
     private Integer favoriteCount;
+    private String projectMembers;
 }

--- a/src/main/java/com/dnd/demo/domain/project/entity/ProjectCategory.java
+++ b/src/main/java/com/dnd/demo/domain/project/entity/ProjectCategory.java
@@ -1,0 +1,15 @@
+package com.dnd.demo.domain.project.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+
+@Entity
+public class ProjectCategory {
+
+    @Id
+    private Long projectId;
+    @Enumerated(EnumType.STRING)
+    private Category category;
+}

--- a/src/main/java/com/dnd/demo/domain/project/entity/ProjectDetail.java
+++ b/src/main/java/com/dnd/demo/domain/project/entity/ProjectDetail.java
@@ -1,0 +1,16 @@
+package com.dnd.demo.domain.project.entity;
+
+import com.dnd.demo.common.entity.BaseEntity;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+
+
+@Entity
+public class ProjectDetail extends BaseEntity {
+
+    @EmbeddedId
+    private ProjectDetailKey projectDetailKey;
+
+    private String detailType;
+    private String detailUrl;
+}

--- a/src/main/java/com/dnd/demo/domain/project/entity/ProjectDetailKey.java
+++ b/src/main/java/com/dnd/demo/domain/project/entity/ProjectDetailKey.java
@@ -1,0 +1,18 @@
+package com.dnd.demo.domain.project.entity;
+
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@NoArgsConstructor
+public class ProjectDetailKey {
+
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long detailId;
+
+    private Long projectId;
+}


### PR DESCRIPTION
ERD 초안에 맞는 엔티티 기본 정보를 생성하고 JPA 기본 세팅을 진행했습니다.

세팅을 하면서 몇가지 논의사항이 있어 PR에 남깁니다. 

1. 도메인 분류 
디렉토리 분류를 얼마나 세분화할 것인지 논의가 필요합니다. 

2. id 생성 전략 +  Auto increment 전략
 sequence 활용전략,  PK 생성 전략을 UUID, auto increment 

3. 연관관계 매핑 전략 
 현재는 매핑 없이 FK값만 멤버변수로 갖도록 세팅했습니다. 

4. 코드값 방식 enum
 직군, Level에 대한 코드값 저장 방식 픽스가 필요합니다.  

5. BaseEntity 멤버변수 픽스

6. 참여자 테이블
 따로 추가할지, String으로 저장에서 split하여 리턴할지 논의가 필요합니다. 

7. null 관련 스펙 후 ERD 픽스 
 최종적으로 논의 후 ERD 픽스 작업이 필요할 것 같습니다. 

한번 읽어보시고 회의 때 논의해보면 좋을 것 같습니다. 