### PR TITLE
feat : 회원검색 및 refresh token 로그아웃 API 초안 추가

### DIFF
--- a/src/main/java/com/dnd/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dnd/demo/domain/member/controller/MemberController.java
@@ -1,0 +1,79 @@
+package com.dnd.demo.domain.member.controller;
+
+
+import com.dnd.demo.common.dto.ApiResponse;
+import com.dnd.demo.domain.member.dto.MemberSearchRequestDto;
+import com.dnd.demo.domain.member.dto.MemberSearchResponseDto;
+import com.dnd.demo.domain.member.dto.TokenDto;
+import com.dnd.demo.domain.member.service.MemberService;
+import com.dnd.demo.global.auth.util.JwtTokenProvider;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "회원 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/members")
+public class MemberController {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberService memberService;
+
+    @Value("${security.auth.header}")
+    private String authHeader;
+
+    // TODO) redis 도입하여 token invalidate 추가
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(HttpServletResponse response) {
+        // 리프레시 토큰 쿠키 삭제
+        Cookie logoutCookie = new Cookie("refresh_token", null);
+        logoutCookie.setHttpOnly(true);
+        logoutCookie.setSecure(true);
+        logoutCookie.setPath("/");
+        logoutCookie.setMaxAge(0);
+        response.addCookie(logoutCookie);
+
+        return ResponseEntity.ok("Logged out successfully");
+    }
+
+    @GetMapping("/refresh")
+    public ResponseEntity<?> refresh(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = jwtTokenProvider.resolveRefreshTokenFromCookie(request);
+        if (refreshToken == null || !jwtTokenProvider.validateToken(refreshToken)) {
+            return ResponseEntity.status(401).body("Invalid Refresh Token");
+        }
+
+        TokenDto tokenDto = jwtTokenProvider.reissueToken(request, refreshToken);
+        Cookie refreshTokenCookie = jwtTokenProvider.getRefreshTokenCookie(tokenDto.refreshToken());
+        response.addCookie(refreshTokenCookie);
+
+        return ResponseEntity.ok()
+          .header(authHeader, tokenDto.grantType() + " " + tokenDto.accessToken())
+          .build();
+    }
+
+    // TODO) email 조회 GET/POST
+    @PostMapping()
+    @Operation(summary = "회원 검색", description = "프로젝트 생성 시 프로젝트 참여자 검색 API.")
+    public ResponseEntity<ApiResponse<MemberSearchResponseDto>> getMember(
+      @RequestBody MemberSearchRequestDto memberSearchRequestDto) {
+        return ResponseEntity.ok(
+          new ApiResponse<>(HttpStatus.OK.value(), "조회 성공",
+            memberService.getMemberByEmail(memberSearchRequestDto)));
+
+    }
+
+
+}

--- a/src/main/java/com/dnd/demo/domain/member/dto/MemberSearchRequestDto.java
+++ b/src/main/java/com/dnd/demo/domain/member/dto/MemberSearchRequestDto.java
@@ -1,0 +1,5 @@
+package com.dnd.demo.domain.member.dto;
+
+public record MemberSearchRequestDto(String email) {
+
+}

--- a/src/main/java/com/dnd/demo/domain/member/dto/MemberSearchResponseDto.java
+++ b/src/main/java/com/dnd/demo/domain/member/dto/MemberSearchResponseDto.java
@@ -1,0 +1,23 @@
+package com.dnd.demo.domain.member.dto;
+
+import com.dnd.demo.domain.member.entity.Member;
+import com.dnd.demo.domain.project.entity.Job;
+import com.dnd.demo.domain.project.entity.Level;
+import lombok.Builder;
+
+@Builder
+public record MemberSearchResponseDto(
+  String email,
+  Job job,
+  Level level
+) {
+
+    public static MemberSearchResponseDto fromEntity(Member member) {
+        return MemberSearchResponseDto.builder()
+          .email(member.getEmail())
+          .job(member.getJob())
+          .level(member.getLevel())
+          .build();
+    }
+
+}

--- a/src/main/java/com/dnd/demo/domain/member/dto/TokenDto.java
+++ b/src/main/java/com/dnd/demo/domain/member/dto/TokenDto.java
@@ -1,0 +1,8 @@
+package com.dnd.demo.domain.member.dto;
+
+import lombok.Builder;
+
+@Builder
+public record TokenDto(String grantType, String accessToken, String refreshToken) {
+
+}

--- a/src/main/java/com/dnd/demo/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/dnd/demo/domain/member/repository/MemberRepository.java
@@ -1,9 +1,10 @@
 package com.dnd.demo.domain.member.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import com.dnd.demo.domain.member.entity.Member;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRepository extends JpaRepository<Member, String> {
 
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/dnd/demo/domain/member/service/MemberService.java
+++ b/src/main/java/com/dnd/demo/domain/member/service/MemberService.java
@@ -1,0 +1,11 @@
+package com.dnd.demo.domain.member.service;
+
+
+import com.dnd.demo.domain.member.dto.MemberSearchRequestDto;
+import com.dnd.demo.domain.member.dto.MemberSearchResponseDto;
+
+public interface MemberService {
+
+    public MemberSearchResponseDto getMemberByEmail(MemberSearchRequestDto memberSearchRequestDto);
+
+}

--- a/src/main/java/com/dnd/demo/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/dnd/demo/domain/member/service/MemberServiceImpl.java
@@ -1,0 +1,23 @@
+package com.dnd.demo.domain.member.service;
+
+
+import com.dnd.demo.domain.member.dto.MemberSearchRequestDto;
+import com.dnd.demo.domain.member.dto.MemberSearchResponseDto;
+import com.dnd.demo.domain.member.entity.Member;
+import com.dnd.demo.domain.member.repository.MemberRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public MemberSearchResponseDto getMemberByEmail(MemberSearchRequestDto memberSearchRequestDto) {
+        Optional<Member> existMember = memberRepository.findByEmail(memberSearchRequestDto.email());
+        return existMember.map(MemberSearchResponseDto::fromEntity).orElse(null);
+    }
+}

--- a/src/main/java/com/dnd/demo/global/auth/dto/OAuthUserDetails.java
+++ b/src/main/java/com/dnd/demo/global/auth/dto/OAuthUserDetails.java
@@ -5,6 +5,7 @@ import com.dnd.demo.domain.member.entity.MemberRole;
 import com.dnd.demo.domain.project.entity.Category;
 import com.dnd.demo.domain.project.entity.Job;
 import com.dnd.demo.domain.project.entity.Level;
+import io.jsonwebtoken.Claims;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import java.util.Collection;
@@ -101,6 +102,13 @@ public class OAuthUserDetails implements OAuth2User {
           .profileUrl(profileUrl)
           .build();
     }
+
+    public static OAuthUserDetails fromToken(Claims claims) {
+        return OAuthUserDetails.builder()
+          .memberId(claims.getSubject())
+          .build();
+    }
+
 
     public Member toEntity() {
         return Member.builder()

--- a/src/main/java/com/dnd/demo/global/auth/handler/OAuthSuccessHandler.java
+++ b/src/main/java/com/dnd/demo/global/auth/handler/OAuthSuccessHandler.java
@@ -1,37 +1,40 @@
 package com.dnd.demo.global.auth.handler;
 
+import com.dnd.demo.domain.member.dto.TokenDto;
+import com.dnd.demo.global.auth.util.JwtTokenProvider;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
-
-import com.dnd.demo.global.auth.util.JwtTokenProvider;
-
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
 @Component
 public class OAuthSuccessHandler implements AuthenticationSuccessHandler {
 
-	private final JwtTokenProvider jwtTokenProvider;
+    private final JwtTokenProvider jwtTokenProvider;
 
-	@Value("${security.auth.header}")
-	private String authHeader;
+    @Value("${security.auth.header}")
+    private String authHeader;
 
-	@Override
-	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
-		Authentication authentication) throws IOException, ServletException {
-		String accessToken = jwtTokenProvider.createToken(authentication.getName(),
-			authentication.getAuthorities());
-		response.setHeader(authHeader, "Bearer " + accessToken);
-		response.sendRedirect("/");
-	}
 
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+      Authentication authentication) throws IOException, ServletException {
+        TokenDto token = jwtTokenProvider.createToken(authentication.getName(),
+          authentication.getAuthorities());
+        response.setHeader(authHeader, token.grantType() + " " + token.accessToken());
+
+        Cookie cookie = jwtTokenProvider.getRefreshTokenCookie(token.refreshToken());
+        response.addCookie(cookie);
+
+        response.sendRedirect("/"); // callback URL
+    }
 }


### PR DESCRIPTION
회원 검색 및 refresh token을 추가했습니다.

로그인 API는 프론트에서 
구글 : {서버 url}/oauth2/authorization/google
카카오 : {서버 url}/oauth2/authorization/kakao

이런식으로 호출하면 저희족에서 콜백만 처리하도록 진행하면 될 것 같습니다.

로그아웃 시에는 invalidate 로직이 있어야하는데 이게 cookie로만은 구현이 어려워서 추후에 redis 도입이 필요할것 같습니다. API는 생성을 했기때문에 추후 내부로직만 변경 진행하겠습니다.