### PR TITLE
내 정보 조회, 온보딩 정보 입력 api 구현

### DIFF
--- a/src/main/java/com/dnd/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dnd/demo/domain/member/controller/MemberController.java
@@ -3,12 +3,21 @@ package com.dnd.demo.domain.member.controller;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.dnd.demo.domain.member.dto.request.OnboardingRequest;
+import com.dnd.demo.domain.member.dto.response.MemberResponse;
 import com.dnd.demo.domain.member.dto.response.PointResponseDto;
+import com.dnd.demo.domain.member.entity.Member;
+import com.dnd.demo.domain.member.repository.MemberRepository;
 import com.dnd.demo.domain.member.service.MemberService;
 import com.dnd.demo.global.auth.dto.OAuthUserDetails;
+import com.dnd.demo.global.exception.CustomException;
+import com.dnd.demo.global.exception.ErrorCode;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,5 +37,22 @@ public class MemberController {
 		@AuthenticationPrincipal OAuthUserDetails userDetails) {
 		int points = memberService.getUserPoints(userDetails.getMemberId());
 		return ResponseEntity.ok(new PointResponseDto(userDetails.getMemberId(), points));
+	}
+
+	@Operation(summary = "온보딩 정보 입력")
+	@PostMapping("/onboarding/{memberId}")
+	public ResponseEntity<String> completeOnboarding(
+		@PathVariable String memberId,
+		@RequestBody OnboardingRequest request) {
+		memberService.completeOnboarding(memberId, request);
+		return ResponseEntity.ok("Onboarding completed");
+	}
+
+	@Operation(summary = "내 정보 조회 (전체 아님)")
+	@GetMapping("/me")
+	public ResponseEntity<MemberResponse> getMemberInfo(
+		@AuthenticationPrincipal OAuthUserDetails userDetails) {
+		MemberResponse response = memberService.getMemberInfo(userDetails.getMemberId());
+		return ResponseEntity.ok(response);
 	}
 }

--- a/src/main/java/com/dnd/demo/domain/member/controller/MemberController.java
+++ b/src/main/java/com/dnd/demo/domain/member/controller/MemberController.java
@@ -45,10 +45,10 @@ public class MemberController {
 		@PathVariable String memberId,
 		@RequestBody OnboardingRequest request) {
 		memberService.completeOnboarding(memberId, request);
-		return ResponseEntity.ok("Onboarding completed");
+		return ResponseEntity.ok("온보딩 입력 정보 업데이트 완료");
 	}
 
-	@Operation(summary = "내 정보 조회 (전체 아님)")
+	@Operation(summary = "내 정보 조회 ")
 	@GetMapping("/me")
 	public ResponseEntity<MemberResponse> getMemberInfo(
 		@AuthenticationPrincipal OAuthUserDetails userDetails) {

--- a/src/main/java/com/dnd/demo/domain/member/dto/request/OnboardingRequest.java
+++ b/src/main/java/com/dnd/demo/domain/member/dto/request/OnboardingRequest.java
@@ -1,0 +1,22 @@
+package com.dnd.demo.domain.member.dto.request;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.dnd.demo.domain.member.entity.MemberCategory;
+import com.dnd.demo.domain.project.enums.Job;
+import com.dnd.demo.domain.project.enums.Level;
+
+public record OnboardingRequest(
+	String email,
+	String nickname,
+	Job job,
+	Level level,
+	List<Long> categoryIds
+) {
+	public List<MemberCategory> toEntity(String memberId, List<Long> categoryIds) {
+		return categoryIds.stream()
+			.map(categoryId -> new MemberCategory(memberId, categoryId))
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/dnd/demo/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/dnd/demo/domain/member/dto/response/MemberResponse.java
@@ -3,6 +3,7 @@ package com.dnd.demo.domain.member.dto.response;
 import java.util.List;
 
 import com.dnd.demo.domain.member.entity.Member;
+import com.dnd.demo.domain.member.entity.MemberRole;
 import com.dnd.demo.domain.project.enums.Job;
 import com.dnd.demo.domain.project.enums.Level;
 
@@ -12,6 +13,10 @@ public record MemberResponse(
 	String email,
 	Job job,
 	Level level,
+	Integer points,
+	String profileUrl,
+	boolean onboardingCompleted,
+	MemberRole role,
 	List<Long> categoryIds
 ) {
 	public static MemberResponse from(Member member, List<Long> categoryIds) {
@@ -21,6 +26,10 @@ public record MemberResponse(
 			member.getEmail(),
 			member.getJob(),
 			member.getLevel(),
+			member.getPoints(),
+			member.getProfileUrl(),
+			member.isOnboardingCompleted(),
+			member.getRole(),
 			categoryIds
 		);
 	}

--- a/src/main/java/com/dnd/demo/domain/member/dto/response/MemberResponse.java
+++ b/src/main/java/com/dnd/demo/domain/member/dto/response/MemberResponse.java
@@ -1,0 +1,27 @@
+package com.dnd.demo.domain.member.dto.response;
+
+import java.util.List;
+
+import com.dnd.demo.domain.member.entity.Member;
+import com.dnd.demo.domain.project.enums.Job;
+import com.dnd.demo.domain.project.enums.Level;
+
+public record MemberResponse(
+	String memberId,
+	String memberName,
+	String email,
+	Job job,
+	Level level,
+	List<Long> categoryIds
+) {
+	public static MemberResponse from(Member member, List<Long> categoryIds) {
+		return new MemberResponse(
+			member.getMemberId(),
+			member.getMemberName(),
+			member.getEmail(),
+			member.getJob(),
+			member.getLevel(),
+			categoryIds
+		);
+	}
+}

--- a/src/main/java/com/dnd/demo/domain/member/entity/Member.java
+++ b/src/main/java/com/dnd/demo/domain/member/entity/Member.java
@@ -18,7 +18,6 @@ import lombok.Setter;
 
 @Entity
 @Getter
-@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -31,18 +30,17 @@ public class Member extends BaseEntity {
     private Job job;
     @Enumerated(EnumType.STRING)
     private Level level;
-    // @Enumerated(EnumType.STRING)
-    // private MemberCategory category;
     private String email;
-    private Integer points = 100;
+    private Integer points ;
     private String memberName;
     private String profileUrl;
+    private boolean onboardingCompleted = false;
 
     @Enumerated(EnumType.STRING)
     private MemberRole role;
 
     public void addPoints(int amount) {
-        this.points += amount;
+        this.points = (this.points == null ? 0 : this.points) + amount;
     }
 
     public void reducePoints(int amount) {
@@ -50,5 +48,16 @@ public class Member extends BaseEntity {
             throw new CustomException(ErrorCode.INSUFFICIENT_POINTS);
         }
         this.points -= amount;
+    }
+
+    public void updateOnboarding(String email, String nickname, Job job, Level level) {
+        this.email = email;
+        this.memberName = nickname;
+        this.job = job;
+        this.level = level;
+    }
+
+    public void updateOnboardingCompleted() {
+        this.onboardingCompleted = true;
     }
 }

--- a/src/main/java/com/dnd/demo/domain/member/entity/MemberCategory.java
+++ b/src/main/java/com/dnd/demo/domain/member/entity/MemberCategory.java
@@ -4,14 +4,23 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor
+@Getter
 public class MemberCategory {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private Long memberId;
+    private String memberId;
     private Long categoryId;
+
+    public MemberCategory(String memberId, Long categoryId) {
+        this.memberId = memberId;
+        this.categoryId = categoryId;
+    }
 }

--- a/src/main/java/com/dnd/demo/domain/member/repository/MemberCategoryRepository.java
+++ b/src/main/java/com/dnd/demo/domain/member/repository/MemberCategoryRepository.java
@@ -1,0 +1,13 @@
+package com.dnd.demo.domain.member.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.dnd.demo.domain.member.entity.MemberCategory;
+
+@Repository
+public interface MemberCategoryRepository extends JpaRepository<MemberCategory, Long> {
+	List<MemberCategory> findByMemberId(String memberId);
+}

--- a/src/main/java/com/dnd/demo/domain/project/repository/CategoryQueryDslRepository.java
+++ b/src/main/java/com/dnd/demo/domain/project/repository/CategoryQueryDslRepository.java
@@ -1,0 +1,7 @@
+package com.dnd.demo.domain.project.repository;
+
+import java.util.List;
+
+public interface CategoryQueryDslRepository {
+	List<Long> findRelatedCategoryIds(List<Long> selectedCategoryIds);
+}

--- a/src/main/java/com/dnd/demo/domain/project/repository/CategoryQueryDslRepositoryImpl.java
+++ b/src/main/java/com/dnd/demo/domain/project/repository/CategoryQueryDslRepositoryImpl.java
@@ -1,0 +1,37 @@
+package com.dnd.demo.domain.project.repository;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.stereotype.Repository;
+
+import com.dnd.demo.domain.project.entity.QCategory;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class CategoryQueryDslRepositoryImpl implements CategoryQueryDslRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<Long> findRelatedCategoryIds(List<Long> selectedCategoryIds) {
+		//선택한 categoryId가 가진 categoryName 찾기
+		List<String> categoryNames = queryFactory
+			.select(QCategory.category.categoryName)
+			.from(QCategory.category)
+			.where(QCategory.category.categoryId.in(selectedCategoryIds))
+			.fetch();
+
+		if (categoryNames.isEmpty()) return Collections.emptyList();
+
+		// 같은 categoryName을 가진 모든 categoryId 조회
+		return queryFactory
+			.select(QCategory.category.categoryId)
+			.from(QCategory.category)
+			.where(QCategory.category.categoryName.in(categoryNames))
+			.fetch();
+	}
+}

--- a/src/main/java/com/dnd/demo/global/auth/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/demo/global/auth/config/SecurityConfig.java
@@ -35,6 +35,7 @@ public class SecurityConfig {
                 auth.requestMatchers(
                         "/",
                         "/login",
+                        "/members/onboarding",
                         "/oauth2/**",
                         "/swagger-ui/**",
                         "/v3/api-docs/**",

--- a/src/main/java/com/dnd/demo/global/auth/handler/OAuthSuccessHandler.java
+++ b/src/main/java/com/dnd/demo/global/auth/handler/OAuthSuccessHandler.java
@@ -4,10 +4,15 @@ import java.io.IOException;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
+import com.dnd.demo.domain.member.entity.Member;
+import com.dnd.demo.domain.member.repository.MemberRepository;
 import com.dnd.demo.global.auth.util.JwtTokenProvider;
+import com.dnd.demo.global.exception.CustomException;
+import com.dnd.demo.global.exception.ErrorCode;
 
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 public class OAuthSuccessHandler implements AuthenticationSuccessHandler {
 
 	private final JwtTokenProvider jwtTokenProvider;
+	private final MemberRepository memberRepository;
 
 	@Value("${security.auth.header}")
 	private String authHeader;
@@ -28,10 +34,19 @@ public class OAuthSuccessHandler implements AuthenticationSuccessHandler {
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) throws IOException, ServletException {
-		String accessToken = jwtTokenProvider.createToken(authentication.getName(),
-			authentication.getAuthorities());
-		response.setHeader(authHeader, "Bearer " + accessToken);
-		response.sendRedirect("/");
-	}
+		String memberId = authentication.getName();
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
 
+		String accessToken = jwtTokenProvider.createToken(memberId, authentication.getAuthorities());
+		response.setHeader(authHeader, "Bearer " + accessToken);
+
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		if (member.isOnboardingCompleted()) {
+			response.sendRedirect("/dashboard.html");
+		} else {
+			response.sendRedirect("/onboarding.html");
+		}
+	}
 }

--- a/src/main/resources/static/dashboard.html
+++ b/src/main/resources/static/dashboard.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>메인 페이지</title>
+    <style>
+        body { font-family: Arial, sans-serif; text-align: center; background: #f3f3f3; }
+        .container { max-width: 600px; margin: 50px auto; padding: 20px; background: white; border-radius: 10px; box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1); }
+        button { background: red; color: white; border: none; cursor: pointer; padding: 10px; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h2>메인 페이지</h2>
+    <p><strong>닉네임:</strong> <span id="nickname"></span></p>
+    <p><strong>이메일:</strong> <span id="email"></span></p>
+    <p><strong>직업:</strong> <span id="job"></span></p>
+    <p><strong>레벨:</strong> <span id="level"></span></p>
+    <p><strong>카테고리:</strong> <span id="categories"></span></p>
+
+    <button onclick="logout()">로그아웃</button>
+</div>
+
+<script>
+    async function loadMemberInfo() {
+        const response = await fetch("/members/me");
+        if (!response.ok) {
+            alert("사용자 정보를 불러올 수 없습니다.");
+            return;
+        }
+
+        const data = await response.json();
+        document.getElementById("nickname").innerText = data.memberName;
+        document.getElementById("email").innerText = data.email;
+        document.getElementById("job").innerText = data.job;
+        document.getElementById("level").innerText = data.level;
+        document.getElementById("categories").innerText = data.categoryIds.join(", ");
+    }
+
+    function logout() {
+        window.location.href = "/logout"; // 로그아웃 후 로그인 페이지로 이동
+    }
+
+    window.onload = loadMemberInfo;
+</script>
+</body>
+</html>

--- a/src/main/resources/static/onboarding.html
+++ b/src/main/resources/static/onboarding.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>온보딩</title>
+    <style>
+        body { font-family: Arial, sans-serif; text-align: center; background: #f3f3f3; }
+        .container { max-width: 400px; margin: 50px auto; padding: 20px; background: white; border-radius: 10px; box-shadow: 0px 4px 6px rgba(0, 0, 0, 0.1); }
+        input, select, button { width: 100%; padding: 10px; margin-top: 10px; }
+        button { background: blue; color: white; border: none; cursor: pointer; }
+    </style>
+</head>
+<body>
+<div class="container">
+    <h2>온보딩 정보 입력</h2>
+    <form id="onboardingForm">
+        <input type="email" id="email" placeholder="이메일 입력" required>
+        <input type="text" id="nickname" placeholder="닉네임 입력" required>
+
+        <label for="job">직업 선택:</label>
+        <select id="job" required>
+            <option value="DEVELOPER">개발자</option>
+            <option value="PLANNER">기획자</option>
+            <option value="DESIGNER">디자이너</option>
+        </select>
+
+        <label for="level">레벨 선택:</label>
+        <select id="level" required>
+            <option value="LEARNER">학습자</option>
+            <option value="PROFESSIONAL">전문가</option>
+        </select>
+
+        <label>관심 카테고리 선택:</label>
+        <div id="category-container">
+            <label><input type="checkbox" name="category" value="1"> 프론트엔드</label>
+            <label><input type="checkbox" name="category" value="2"> 백엔드</label>
+            <label><input type="checkbox" name="category" value="3"> 데이터 사이언스</label>
+        </div>
+
+        <button type="submit">저장 후 시작하기</button>
+    </form>
+</div>
+
+<script>
+    document.getElementById("onboardingForm").addEventListener("submit", async function(event) {
+        event.preventDefault();
+
+        const email = document.getElementById("email").value;
+        const nickname = document.getElementById("nickname").value;
+        const job = document.getElementById("job").value;
+        const level = document.getElementById("level").value;
+
+        // 체크된 카테고리 가져오기
+        const selectedCategories = Array.from(document.querySelectorAll('input[name="category"]:checked'))
+            .map(cb => cb.value);
+
+        const response = await fetch("/members/onboarding", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ email, nickname, job, level, categoryIds: selectedCategories }),
+        });
+
+        if (response.ok) {
+            window.location.href = "/dashboard.html"; // 온보딩 후 메인 페이지로 이동
+        } else {
+            alert("오류 발생! 다시 시도하세요.");
+        }
+    });
+</script>
+</body>
+</html>


### PR DESCRIPTION
**OAuthSuccessHandler 코드 임시 수정**
- Member Entity에 onboardingCompleted 필드 추가
- onboardingCompleted TURE이면 메인 페이지 , FALSE이면 온보딩 페이지로 리다이렉트 되도록 임시 구현

**온보딩 정보 입력 api 추가**
- 로그인 후 온보딩 페이지에서 입력 받았을 때 Memeber 정보 업데이트, MemberCategory 저장, 포인트 지급

**추천순 프로젝트 전체 조회 수정**
- 사용자  온보딩 때 입력한 정보 기반으로 조회되도록 수정

**내 정보 조회 api 추가**