### PR TITLE
같은 카테고리를 가진 프로젝트 전체 조회 api 구현

### DIFF
--- a/src/main/java/com/dnd/demo/domain/project/controller/ProjectController.java
+++ b/src/main/java/com/dnd/demo/domain/project/controller/ProjectController.java
@@ -22,6 +22,7 @@ import com.dnd.demo.domain.member.dto.response.PointResponseDto;
 import com.dnd.demo.domain.project.dto.request.ProjectCreateRequest;
 import com.dnd.demo.domain.project.dto.request.TemporaryProjectCreateRequest;
 import com.dnd.demo.domain.project.dto.response.AdvertisedProjectResponseDto;
+import com.dnd.demo.domain.project.dto.response.ProjectCategoryRecommendationResponseDto;
 import com.dnd.demo.domain.project.dto.response.ProjectListResponseDto;
 import com.dnd.demo.domain.project.dto.response.ProjectResponseDto;
 import com.dnd.demo.domain.project.enums.Job;
@@ -105,4 +106,12 @@ public class ProjectController {
 		projectService.deleteProject(oAuthUserDetails.getMemberId(), projectId);
 		return ResponseEntity.ok(new ApiResponse<>(HttpStatus.OK.value(), "프로젝트 삭제 성공", null));
 	}
+
+	@Operation(summary = "연관 카테고리 프로젝트 조회", description = "특정 프로젝트와 같은 카테고리를 가진 프로젝트 목록 조회")
+	@GetMapping("/{projectId}/related")
+	public ResponseEntity<List<ProjectCategoryRecommendationResponseDto>> getRelatedProjects(
+		@PathVariable Long projectId) {
+		return ResponseEntity.ok(projectService.getRelatedProjects(projectId));
+	}
+
 }

--- a/src/main/java/com/dnd/demo/domain/project/dto/response/ProjectCategoryRecommendationResponseDto.java
+++ b/src/main/java/com/dnd/demo/domain/project/dto/response/ProjectCategoryRecommendationResponseDto.java
@@ -1,0 +1,33 @@
+package com.dnd.demo.domain.project.dto.response;
+
+import com.dnd.demo.domain.project.entity.Project;
+import com.dnd.demo.domain.project.enums.Job;
+import com.dnd.demo.domain.project.enums.Level;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProjectCategoryRecommendationResponseDto {
+
+	private Long projectId;
+	private String title;
+	private Level targetLevel;
+	private Job targetJob;
+	private String description;
+	private String thumbnailImgUrl;
+	private String logoImgUrl;
+
+	public static ProjectCategoryRecommendationResponseDto from(Project project) {
+		return ProjectCategoryRecommendationResponseDto.builder()
+			.projectId(project.getProjectId())
+			.title(project.getTitle())
+			.targetLevel(project.getTargetLevel())
+			.targetJob(project.getTargetJob())
+			.description(project.getDescription())
+			.thumbnailImgUrl(project.getThumbnailImgUrl())
+			.logoImgUrl(project.getLogoImgUrl())
+			.build();
+	}
+}

--- a/src/main/java/com/dnd/demo/domain/project/repository/ProjectQueryDslRepository.java
+++ b/src/main/java/com/dnd/demo/domain/project/repository/ProjectQueryDslRepository.java
@@ -20,4 +20,5 @@ public interface ProjectQueryDslRepository {
 
 	Optional<Project> findLatestTemporaryProject(String memberId);
 
+	List<Long> findProjectIdsByCategoryIds(List<Long> categoryIds);
 }

--- a/src/main/java/com/dnd/demo/domain/project/repository/ProjectQueryDslRepositoryImpl.java
+++ b/src/main/java/com/dnd/demo/domain/project/repository/ProjectQueryDslRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com.dnd.demo.domain.project.repository;
 
+import static com.dnd.demo.domain.project.entity.QProjectCategory.*;
+
 import com.dnd.demo.domain.member.entity.Member;
 import com.dnd.demo.domain.member.entity.QFavorite;
 import com.dnd.demo.domain.member.entity.QMember;
@@ -158,4 +160,18 @@ public class ProjectQueryDslRepositoryImpl implements ProjectQueryDslRepository 
 
         return Optional.ofNullable(result);
     }
+
+    @Override
+    public List<Long> findProjectIdsByCategoryIds(List<Long> categoryIds) {
+        return queryFactory
+            .select(projectCategory.projectId)
+            .from(projectCategory)
+            .join(project).on(projectCategory.projectId.eq(project.projectId))
+            .where(
+                projectCategory.categoryId.in(categoryIds),
+                project.projectStatus.eq(ProjectStatus.OPEN)
+            )
+            .fetch();
+    }
+
 }

--- a/src/main/java/com/dnd/demo/domain/project/service/ProjectCategoryService.java
+++ b/src/main/java/com/dnd/demo/domain/project/service/ProjectCategoryService.java
@@ -60,4 +60,9 @@ public class ProjectCategoryService {
 		List<Category> categories = categoryRepository.findByCategoryIdIn(categoryIds);
 		return PlatformCategoryResponse.from(categories);
 	}
+
+	@Transactional(readOnly = true)
+	public List<Long> getCategoryIdsByProjectId(Long projectId) {
+		return projectCategoryRepository.findCategoryIdsByProjectId(projectId);
+	}
 }

--- a/src/main/java/com/dnd/demo/domain/project/service/ProjectService.java
+++ b/src/main/java/com/dnd/demo/domain/project/service/ProjectService.java
@@ -13,6 +13,7 @@ import com.dnd.demo.domain.project.dto.request.ProjectSaveRequest;
 import com.dnd.demo.domain.project.dto.request.TemporaryProjectCreateRequest;
 import com.dnd.demo.domain.project.dto.response.AdvertisedProjectResponseDto;
 import com.dnd.demo.domain.project.dto.response.PlatformCategoryResponse;
+import com.dnd.demo.domain.project.dto.response.ProjectCategoryRecommendationResponseDto;
 import com.dnd.demo.domain.project.dto.response.ProjectDetailResponse;
 import com.dnd.demo.domain.project.dto.response.ProjectListResponseDto;
 import com.dnd.demo.domain.project.dto.response.ProjectResponseDto;
@@ -177,4 +178,17 @@ public class ProjectService {
             throw new CustomException(ErrorCode.PROJECT_FINAL_CREATE_ALREADY_UPLOAD);
         }
     }
+
+    @Transactional(readOnly = true)
+    public List<ProjectCategoryRecommendationResponseDto> getRelatedProjects(Long projectId) {
+        List<Long> categoryIds = projectCategoryService.getCategoryIdsByProjectId(projectId);
+        List<Long> relatedProjectIds = projectQueryDslRepository.findProjectIdsByCategoryIds(categoryIds);
+
+        List<Project> relatedProjects = projectRepository.findByProjectIdIn(relatedProjectIds);
+
+        return relatedProjects.stream()
+            .map(ProjectCategoryRecommendationResponseDto::from)
+            .toList();
+    }
+
 }


### PR DESCRIPTION
해당 브랜치 머지된 것 확인 못하고 여기서 작업 후 커밋 후  푸시까지 해버려서 해당 브랜치로 다시  PR 올립니다.

1개라도 같은 카테고리 있다면 조회되도록 구현

1. 프로젝트의 카테고리 ID 리스트 조회
2. 해당 카테고리를 포함하는 모든 프로젝트 ID 리스트 조회
3. 프로젝트 ID로 프로젝트 정보 조회 및 DTO 변환